### PR TITLE
Attachments with invalid data

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -213,6 +213,9 @@ button.imgt-virgin {
 	color: #65727C;
 	opacity: .9;
 }
+.row-error .imgt-small-info {
+	color: #fff;
+}
 
 /**
  * === Tables

--- a/assets/css/admin.min.css
+++ b/assets/css/admin.min.css
@@ -1,1 +1,287 @@
-@charset "UTF-8";[class*=" imgt-"],[class^=imgt-]{-webkit-box-sizing:border-box;box-sizing:border-box}[class*=" imgt-"] a,[class^=imgt-] a{color:#338EA6;font-weight:700}[class^=imgt-] ::selection{background:#338EA6;color:#FFF}[class^=imgt-] ::-moz-selection{background:#338EA6;color:#FFF}[class^=imgt-] .text,[class^=imgt-] a,[class^=imgt-] button,[class^=imgt-] input{-webkit-transition:all .275s;-o-transition:all .275s;transition:all .275s;outline:0;-webkit-box-shadow:none;box-shadow:none}button.imgt-virgin{padding:0;border:0;background:0 0;height:auto;-webkit-box-shadow:none;box-shadow:none;text-shadow:none}.imgt-button-primary.imgt-button-primary,.imgt-button-secondary.imgt-button-secondary,.imgt-button-tertiary.imgt-button-tertiary,.imgt-button.imgt-button{display:inline-block;height:auto;margin:.1em 0;padding:7px 20px 8px;border:0;font-size:14px;line-height:1.5;font-weight:700;text-transform:uppercase;color:#FFF;text-decoration:none;text-shadow:none;background:#65727C;-webkit-box-shadow:none;box-shadow:none;white-space:nowrap;border-radius:3px;-webkit-appearance:none;cursor:pointer}.imgt-button-primary.imgt-button-primary:focus,.imgt-button-primary.imgt-button-primary:hover,.imgt-button-secondary.imgt-button-secondary:focus,.imgt-button-secondary.imgt-button-secondary:hover,.imgt-button-tertiary.imgt-button-tertiary:focus,.imgt-button-tertiary.imgt-button-tertiary:hover,.imgt-button.imgt-button:focus,.imgt-button.imgt-button:hover{color:#FFF;background:#2E3243}.imgt-button::-moz-focus-inner,[class^=imgt-button-]::-moz-focus-inner{padding:0;border:0}.imgt-button .text,[class^=imgt-button-] .text{display:inline-block;vertical-align:middle}[class*=imgt-button].disabled,[class*=imgt-button]:disabled{opacity:.5;cursor:not-allowed}.imgt-button.imgt-button.light{background:#ADB1B7}.imgt-button.imgt-button.light:focus,.imgt-button.imgt-button.light:hover{background:#2E3243}.imgt-button-primary.imgt-button-primary{background:#40B1D0}.imgt-button-primary.imgt-button-primary:focus,.imgt-button-primary.imgt-button-primary:hover{background:#338EA6}.imgt-button-secondary.imgt-button-secondary{background:#DF3883}.imgt-button-secondary.imgt-button-secondary:focus,.imgt-button-secondary.imgt-button-secondary:hover{background:#C51162}.imgt-button-mini.imgt-button-mini{font-size:11px;padding:2px 10px 3px;letter-spacing:.125em}.imgt-button-big.imgt-button-big{font-size:18px}.imgt-wrap>.imgt-button-uninstall{margin-top:16px;margin-right:12px}.imgt-flex,.imgt-flex-spaced{position:relative;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-ms-flex-direction:row;flex-direction:row;-webkit-box-align:center;-ms-flex-align:center;align-items:center}.imgt-flex>*{-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1;margin:0}.imgt-wrap{clear:both}[id=screen-meta-links]+.imgt-wrap{margin-top:40px}.imgt-wrap .imgt-page-title{padding:20px 12px;background:#2E3243;color:#F2F5F7}.imgt-wrap .tablenav{display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:justify;-ms-flex-pack:justify;justify-content:space-between;-webkit-box-align:center;-ms-flex-align:center;align-items:center}.imgt-logs-list .tablenav .imgt-quick-actions{margin:0 auto}.imgt-wrap pre{width:100%;margin:0;overflow-x:auto}.imgt-small-info{font-weight:700;font-size:.7rem;color:#65727C;opacity:.9}.imgt-wrap tfoot th[scope=col],.imgt-wrap thead th[scope=col]{padding:12px 10px;text-transform:uppercase;letter-spacing:.04em;font-weight:700;background:#2E3243;color:#F2F5F7}.imgt-wrap thead th[scope=col]{background:#1F2332;border-bottom:0}.imgt-wrap tfoot th[scope=col]{border-top:0}.imgt-wrap .wp-list-table{border-bottom:0}.imgt-wrap .wp-list-table tfoot tr>*,.imgt-wrap .wp-list-table thead tr>*{padding:8px 10px;background:#1F2332;color:#F2F5F7;border-bottom:0;border-top:0}.imgt-wrap .wp-list-table .sorting-indicator:before{color:#FFF}.imgt-wrap .wp-list-table #cb{padding:8px 4px}.imgt-wrap .wp-list-table tfoot a,.imgt-wrap .wp-list-table thead a{color:inherit}.imgt-wrap .widefat,.imgt-wrap .wp-list-table{border-top:0;width:calc(100% + 2px);margin:0 -1px}.imgt-wrap .row-group-title th{border-top:25px solid #FFF;background:#338EA6;color:#F2F5F7;font-weight:700}.imgt-wrap tbody>.row-group-title:first-child th{border-top:0}.imgt-wrap tr+tr td,.imgt-wrap tr+tr th{border-top:1px solid #e5e5e5}.imgt-wrap .row-error td,.imgt-wrap .row-error th{color:#fff;font-weight:700;background:#C51162}
+@charset "UTF-8";
+
+/**
+ * ==== TABLE OF COLORS ===
+ *
+ * Red			: #DF3883;#
+ * RedDark		: #C51162;#
+ * Blue         : #40B1D0;#
+ * BlueDark     : #338EA6;#
+ * Green		: #8BC34A;#
+ * GreenDark	: #6F9C3B;#
+ * Dark			: #1F2332;#
+ * GrayLight	: #F2F5F7;#
+ * GrayMedium	: #65727C;#
+ * GrayDark		: #2E3243;#
+ *
+ */
+
+/**
+ * === Generics
+ */
+[class^="imgt-"],
+[class*=" imgt-"] {
+	box-sizing: border-box;
+}
+[class^="imgt-"] a,
+[class*=" imgt-"] a {
+	color: #338EA6;
+	font-weight: bold;
+}
+/* On text selection */
+[class^="imgt-"] ::selection {
+	background: #338EA6;
+	color: #FFF;
+}
+[class^="imgt-"] ::-moz-selection {
+	background: #338EA6;
+	color: #FFF;
+}
+
+/* Animations */
+[class^="imgt-"] a,
+[class^="imgt-"] button,
+[class^="imgt-"] input,
+[class^="imgt-"] .text {
+	transition: all .275s;
+	outline: none;
+	box-shadow: none;
+}
+
+/**
+ * === Buttons
+ */
+button.imgt-virgin {
+	padding: 0;
+	border: 0;
+	background: transparent;
+	height: auto;
+	box-shadow: none;
+	text-shadow: none;
+}
+.imgt-button.imgt-button,
+.imgt-button-primary.imgt-button-primary,
+.imgt-button-secondary.imgt-button-secondary,
+.imgt-button-tertiary.imgt-button-tertiary {
+	display: inline-block;
+	height: auto; /* Yeah 'cause WP locked it */
+	margin: .1em 0;
+	padding: 7px 20px 8px;
+	border: 0;
+	font-size: 14px;
+	line-height: 1.5;
+	font-weight: bold;
+	text-transform: uppercase;
+	color: #FFF;
+	text-decoration: none;
+	text-shadow: none;
+	background: #65727C;
+	box-shadow: none;
+	white-space: nowrap;
+	-webkit-border-radius: 3px;
+	border-radius: 3px;
+	-webkit-appearance: none;
+	cursor: pointer;
+}
+.imgt-button.imgt-button:hover,
+.imgt-button.imgt-button:focus,
+.imgt-button-primary.imgt-button-primary:hover,
+.imgt-button-primary.imgt-button-primary:focus,
+.imgt-button-secondary.imgt-button-secondary:hover,
+.imgt-button-secondary.imgt-button-secondary:focus,
+.imgt-button-tertiary.imgt-button-tertiary:hover,
+.imgt-button-tertiary.imgt-button-tertiary:focus {
+	color: #FFF;
+	background: #2E3243;
+}
+[class^="imgt-button-"]::-moz-focus-inner,
+.imgt-button::-moz-focus-inner {
+	padding: 0;
+	border: 0
+}
+.imgt-button .text,
+[class^="imgt-button-"] .text {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+/* Disabled */
+[class*="imgt-button"].disabled,
+[class*="imgt-button"]:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+/* Not important */
+.imgt-button.imgt-button.light {
+	background: #ADB1B7;
+}
+.imgt-button.imgt-button.light:hover,
+.imgt-button.imgt-button.light:focus {
+	background: #2E3243;
+}
+
+/* Button Colors */
+.imgt-button-primary.imgt-button-primary {
+	background: #40B1D0;
+}
+.imgt-button-primary.imgt-button-primary:hover,
+.imgt-button-primary.imgt-button-primary:focus {
+	background: #338EA6;
+}
+.imgt-button-secondary.imgt-button-secondary {
+	background: #DF3883;
+}
+.imgt-button-secondary.imgt-button-secondary:hover,
+.imgt-button-secondary.imgt-button-secondary:focus {
+	background: #C51162;
+}
+
+/* Buttons sizes */
+.imgt-button-mini.imgt-button-mini {
+	font-size: 11px;
+	padding: 2px 10px 3px;
+	letter-spacing: 0.125em;
+}
+.imgt-button-big.imgt-button-big {
+	font-size: 18px;
+}
+
+/* Specific buttons */
+.imgt-wrap > .imgt-button-uninstall {
+	margin-top: 16px;
+	margin-right: 12px;
+}
+
+/**
+ * === Flexbox
+ */
+.imgt-flex,
+.imgt-flex-spaced {
+	position: relative;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+}
+.imgt-flex > * {
+	flex-grow: 1;
+}
+.imgt-flex > * {
+	margin: 0;
+}
+
+/**
+ * === Containers
+ */
+.imgt-wrap {
+	clear: both;
+}
+[id="screen-meta-links"] + .imgt-wrap {
+	margin-top: 40px;
+}
+
+/**
+ * === Headers
+ */
+.imgt-wrap .imgt-page-title {
+	padding: 20px 12px;
+	background: #2E3243;
+	color: #F2F5F7;
+}
+
+/* Quick actions part */
+.imgt-wrap .tablenav {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+.imgt-logs-list .tablenav .imgt-quick-actions {
+	margin: 0 auto;
+}
+
+/**
+ * === Contents
+ */
+.imgt-wrap pre {
+	width: 100%;
+	margin: 0;
+	overflow-x: auto;
+}
+
+.imgt-small-info {
+	font-weight: bold;
+	font-size: .7rem;
+	color: #65727C;
+	opacity: .9;
+}
+.row-error .imgt-small-info {
+	color: #fff;
+}
+
+/**
+ * === Tables
+ */
+.imgt-wrap thead th[scope="col"],
+.imgt-wrap tfoot th[scope="col"] {
+	padding: 12px 10px;
+	text-transform: uppercase;
+	letter-spacing: .04em;
+	font-weight: bold;
+	background: #2E3243;
+	color: #F2F5F7;
+}
+.imgt-wrap thead th[scope="col"] {
+	background: #1F2332;
+}
+.imgt-wrap thead th[scope="col"] {
+	border-bottom: 0;
+}
+.imgt-wrap tfoot th[scope="col"] {
+	border-top: 0;
+}
+.imgt-wrap .wp-list-table {
+	border-bottom: 0;
+}
+.imgt-wrap .wp-list-table thead tr > *,
+.imgt-wrap .wp-list-table tfoot tr > * {
+	padding: 8px 10px;
+	background: #1F2332;
+	color: #F2F5F7;
+	border-bottom: 0;
+	border-top: 0;
+}
+.imgt-wrap .wp-list-table .sorting-indicator:before {
+	color: #FFF;
+}
+.imgt-wrap .wp-list-table #cb {
+	padding: 8px 4px;
+}
+.imgt-wrap .wp-list-table thead a,
+.imgt-wrap .wp-list-table tfoot a {
+	color: inherit;
+}
+.imgt-wrap .wp-list-table,
+.imgt-wrap .widefat {
+	border-top: 0;
+	width: calc(100% + 2px);
+	margin: 0 -1px;
+}
+.imgt-wrap .row-group-title th {
+	border-top: 25px solid #FFF;
+	background: #338EA6;
+	color: #F2F5F7;
+	font-weight: bold;
+}
+.imgt-wrap tbody > .row-group-title:first-child th {
+	border-top: 0;
+}
+
+.imgt-wrap tr + tr th,
+.imgt-wrap tr + tr td {
+	border-top: 1px solid #e5e5e5;
+}
+.imgt-wrap .row-error th,
+.imgt-wrap .row-error td {
+	color: #fff;
+	font-weight: bold;
+	background: #C51162;
+}

--- a/classes/class-imgt-admin-model-main.php
+++ b/classes/class-imgt-admin-model-main.php
@@ -15,7 +15,7 @@ class IMGT_Admin_Model_Main {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.0';
+	const VERSION = '1.0.1';
 
 	/**
 	 * Info cache duration in minutes.
@@ -251,6 +251,20 @@ class IMGT_Admin_Model_Main {
 				),
 			),
 			__( 'Requests Tests', 'imagify-tools' ) => $requests,
+			__( 'Attachments', 'imagify-tools' ) => array(
+				array(
+					'label'     => __( 'Attachments without mandatory WP metas', 'imagify-tools' ),
+					'value'     => $this->count_medias_without_wp_metas(),
+					'is_error'  => $this->count_medias_without_wp_metas() > 0,
+					'more_info' => $this->get_clear_cache_link( 'imgt_medias_no_wp_metas', 'clear_medias_without_wp_metas_cache' ),
+				),
+				array(
+					'label'     => __( 'Attachments with invalid WP metas', 'imagify-tools' ),
+					'value'     => $this->count_medias_with_invalid_wp_metas(),
+					'is_error'  => $this->count_medias_with_invalid_wp_metas() > 0,
+					'more_info' => $this->get_clear_cache_link( 'imgt_medias_invalid_wp_metas', 'clear_medias_with_invalid_wp_metas_cache' ),
+				),
+			),
 			__( 'Various Tests and Values', 'imagify-tools' ) => array(
 				array(
 					'label'     => __( 'Your IP address', 'imagify-tools' ),
@@ -298,8 +312,8 @@ class IMGT_Admin_Model_Main {
 				),
 				array(
 					'label'     => __( 'Imagify User', 'imagify-tools' ),
-					'value'     => $this->get_imagify_user() ? $this->get_imagify_user() : __( 'Needs Imagify to be installed', 'imagify-tools' ),
-					'more_info' => $this->get_clear_imagify_user_cache_link(),
+					'value'     => $this->get_imagify_user(),
+					'more_info' => $this->get_clear_cache_link( 'imgt_user', 'clear_imagify_user_cache' ),
 				),
 				array(
 					'label'     => '$_SERVER',
@@ -404,41 +418,159 @@ class IMGT_Admin_Model_Main {
 	 * @return string
 	 */
 	protected function get_clear_request_cache_link( $url, $method = 'GET' ) {
-		$link  = $this->are_requests_blocked( $url, $method ) ? '<br/>' : '';
-		$link .= ' <a class="imgt-button imgt-button-ternary imgt-button-mini" href="' . esc_url( $this->get_clear_request_cache_url( $url, $method ) ) . '">' . __( 'Clear cache', 'imagify-tools' ) . '</a>';
+		$line_break     = $this->are_requests_blocked( $url, $method ) ? '<br/>' : '';
+		$method         = strtoupper( $method );
+		$transient_name = substr( md5( "$url|$method" ), 0, 10 );
 
-		$method            = strtoupper( $method );
-		$transient_name    = self::REQUEST_CACHE_PREFIX . substr( md5( "$url|$method" ), 0, 10 );
-		$transient_timeout = $this->get_transient_timeout( $transient_name );
-		$current_time      = time();
-
-		if ( ! $transient_timeout || $transient_timeout < $current_time ) {
-			$time_diff = self::CACHE_DURATION;
-		} else {
-			$time_diff = $transient_timeout - $current_time;
-			$time_diff = ceil( $time_diff / MINUTE_IN_SECONDS );
-		}
-
-		/* translators: %d is a number of minutes. */
-		return $link .= ' <span class="imgt-small-info">(' . sprintf( _n( 'cache cleared in less than %d minute', 'cache cleared in less than %d minutes', $time_diff, 'imagify-tools' ), $time_diff ) . ')</span>';
+		return $line_break . $this->get_clear_cache_link( self::REQUEST_CACHE_PREFIX . $transient_name, 'clear_request_cache', array( 'cache' => $transient_name ) );
 	}
 
 	/**
-	 * Get the URL to clear the request cache (delete the transient).
+	 * Get all mime types which could be optimized by Imagify.
 	 *
-	 * @since  1.0
+	 * @since  1.0.2
 	 * @author Grégory Viguier
 	 *
-	 * @param  string $url    An URL.
-	 * @param  string $method The http method to use.
-	 * @return string
+	 * @return array The mime types.
 	 */
-	protected function get_clear_request_cache_url( $url, $method = 'GET' ) {
-		$method    = strtoupper( $method );
-		$cache_key = substr( md5( "$url|$method" ), 0, 10 );
-		$action    = IMGT_Admin_Post::get_action( 'clear_request_cache' );
+	public function get_mime_types() {
+		if ( function_exists( 'imagify_get_mime_types' ) ) {
+			return imagify_get_mime_types();
+		}
 
-		return wp_nonce_url( admin_url( 'admin-post.php?action=' . $action . '&cache=' . $cache_key ), $action );
+		return array(
+			'jpg|jpeg|jpe' => 'image/jpeg',
+			'png'          => 'image/png',
+			'gif'          => 'image/gif',
+		);
+	}
+
+	/**
+	 * Get post statuses related to attachments.
+	 *
+	 * @since  1.0.2
+	 * @author Grégory Viguier
+	 *
+	 * @return array The post statuses.
+	 */
+	public function get_post_statuses() {
+		static $statuses;
+
+		if ( function_exists( 'imagify_get_post_statuses' ) ) {
+			return imagify_get_post_statuses();
+		}
+
+		if ( isset( $statuses ) ) {
+			return $statuses;
+		}
+
+		$statuses = array(
+			'inherit' => 'inherit',
+			'private' => 'private',
+		);
+
+		$custom_statuses = get_post_stati( array( 'public' => true ) );
+		unset( $custom_statuses['publish'] );
+
+		if ( $custom_statuses ) {
+			$statuses = array_merge( $statuses, $custom_statuses );
+		}
+
+		return $statuses;
+	}
+
+	/**
+	 * Get the number of attachment where the mandatory post metas are missing.
+	 *
+	 * @since  1.0.2
+	 * @author Grégory Viguier
+	 *
+	 * @return int
+	 */
+	protected function count_medias_without_wp_metas() {
+		global $wpdb;
+		static $transient_value;
+
+		if ( isset( $transient_value ) ) {
+			return $transient_value;
+		}
+
+		$transient_name  = 'imgt_medias_no_wp_metas';
+		$transient_value = imagify_tools_get_site_transient( $transient_name );
+
+		if ( false !== $transient_value ) {
+			return (int) $transient_value;
+		}
+
+		$mime_types = esc_sql( $this->get_mime_types() );
+		$mime_types = "'" . implode( "','", $mime_types ) . "'";
+		$statuses   = esc_sql( $this->get_post_statuses() );
+		$statuses   = "'" . implode( "','", $statuses ) . "'";
+
+		$transient_value = $wpdb->get_var( // WPCS: unprepared SQL ok.
+			"
+			SELECT COUNT( p.ID )
+			FROM $wpdb->posts AS p
+			LEFT JOIN $wpdb->postmeta AS mt1
+				ON ( p.ID = mt1.post_id AND mt1.meta_key = '_wp_attached_file' )
+			LEFT JOIN $wpdb->postmeta AS mt2
+				ON ( p.ID = mt2.post_id AND mt2.meta_key = '_wp_attachment_metadata' )
+			WHERE p.post_mime_type IN ( $mime_types )
+				AND p.post_type = 'attachment'
+				AND p.post_status IN ( $statuses )
+				AND ( mt1.meta_value IS NULL OR mt2.meta_value IS NULL )"
+		);
+
+		imagify_tools_set_site_transient( $transient_name, $transient_value, self::CACHE_DURATION * MINUTE_IN_SECONDS );
+
+		return $transient_value;
+	}
+
+	/**
+	 * Get the number of attachment where the post meta '_wp_attached_file' can't be worked with.
+	 *
+	 * @since  1.0.2
+	 * @author Grégory Viguier
+	 *
+	 * @return int
+	 */
+	protected function count_medias_with_invalid_wp_metas() {
+		global $wpdb;
+		static $transient_value;
+
+		if ( isset( $transient_value ) ) {
+			return $transient_value;
+		}
+
+		$transient_name  = 'imgt_medias_invalid_wp_metas';
+		$transient_value = imagify_tools_get_site_transient( $transient_name );
+
+		if ( false !== $transient_value ) {
+			return (int) $transient_value;
+		}
+
+		$mime_types = $this->get_mime_types();
+		$extensions = implode( '|', array_keys( $mime_types ) );
+		$mime_types = esc_sql( $mime_types );
+		$mime_types = "'" . implode( "','", $mime_types ) . "'";
+		$statuses   = esc_sql( $this->get_post_statuses() );
+		$statuses   = "'" . implode( "','", $statuses ) . "'";
+
+		$transient_value = $wpdb->get_var( // WPCS: unprepared SQL ok.
+			"
+			SELECT COUNT( p.ID )
+			FROM $wpdb->posts AS p
+			LEFT JOIN $wpdb->postmeta AS mt1
+				ON ( p.ID = mt1.post_id AND mt1.meta_key = '_wp_attached_file' )
+			WHERE p.post_mime_type IN ( $mime_types )
+				AND p.post_type = 'attachment'
+				AND p.post_status IN ( $statuses )
+				AND ( mt1.meta_value LIKE '%://%' OR mt1.meta_value LIKE '_:\\\\\%' OR LOWER( mt1.meta_value ) NOT REGEXP '.+\.($extensions)' )"
+		);
+
+		imagify_tools_set_site_transient( $transient_name, $transient_value, self::CACHE_DURATION * MINUTE_IN_SECONDS );
+
+		return $transient_value;
 	}
 
 	/**
@@ -447,13 +579,13 @@ class IMGT_Admin_Model_Main {
 	 * @since  1.0
 	 * @author Grégory Viguier
 	 *
-	 * @return object|null
+	 * @return object|string
 	 */
 	protected function get_imagify_user() {
 		static $imagify_user;
 
 		if ( ! function_exists( 'get_imagify_user' ) ) {
-			return null;
+			return __( 'Needs Imagify to be installed', 'imagify-tools' );
 		}
 
 		if ( isset( $imagify_user ) ) {
@@ -471,21 +603,20 @@ class IMGT_Admin_Model_Main {
 	}
 
 	/**
-	 * Get the link to clear the Imagify user cache (delete the transient).
+	 * Get the link to clear a cache (delete the transient).
 	 *
 	 * @since  1.0
 	 * @author Grégory Viguier
 	 *
+	 * @param  string $transient_name Name of the transient that stores the data.
+	 * @param  string $clear_action   Admin post action.
+	 * @param  array  $args           Parameters to add to the link URL.
 	 * @return string
 	 */
-	protected function get_clear_imagify_user_cache_link() {
-		if ( ! $this->get_imagify_user() ) {
-			return '';
-		}
+	protected function get_clear_cache_link( $transient_name, $clear_action, $args = array() ) {
+		$link = ' <a class="imgt-button imgt-button-ternary imgt-button-mini" href="' . esc_url( $this->get_clear_cache_url( $clear_action, $args ) ) . '">' . __( 'Clear cache', 'imagify-tools' ) . '</a>';
 
-		$link = ' <a class="imgt-button imgt-button-ternary imgt-button-mini" href="' . esc_url( $this->get_clear_imagify_user_cache_url() ) . '">' . __( 'Clear cache', 'imagify-tools' ) . '</a>';
-
-		$transient_timeout = $this->get_transient_timeout( 'imgt_user' );
+		$transient_timeout = $this->get_transient_timeout( $transient_name );
 		$current_time      = time();
 
 		if ( ! $transient_timeout || $transient_timeout < $current_time ) {
@@ -500,17 +631,20 @@ class IMGT_Admin_Model_Main {
 	}
 
 	/**
-	 * Get the URL to clear the Imagify user cache (delete the transient).
+	 * Get the URL to clear a cache (delete the transient).
 	 *
 	 * @since  1.0
 	 * @author Grégory Viguier
 	 *
+	 * @param  string $action Admin post action.
+	 * @param  array  $args   Parameters to add to the link URL.
 	 * @return string
 	 */
-	protected function get_clear_imagify_user_cache_url() {
-		$action = IMGT_Admin_Post::get_action( 'clear_imagify_user_cache' );
+	protected function get_clear_cache_url( $action, $args = array() ) {
+		$action = IMGT_Admin_Post::get_action( $action );
+		$url    = wp_nonce_url( admin_url( 'admin-post.php?action=' . $action ), $action );
 
-		return wp_nonce_url( admin_url( 'admin-post.php?action=' . $action ), $action );
+		return $args ? add_query_arg( $args, $url ) : $url;
 	}
 
 	/**

--- a/classes/class-imgt-admin-post.php
+++ b/classes/class-imgt-admin-post.php
@@ -96,9 +96,6 @@ class IMGT_Admin_Post {
 		// Clear Imagify user cache.
 		add_action( 'admin_post_' . self::get_action( 'clear_imagify_user_cache' ),                 array( $this, 'clear_imagify_user_cache_cb' ) );
 
-		// Clear missing metas cache.
-		add_action( 'admin_post_' . self::get_action( 'clear_medias_without_wp_metas_cache' ),      array( $this, 'clear_medias_without_wp_metas_cache_cb' ) );
-
 		// Clear invalid metas cache.
 		add_action( 'admin_post_' . self::get_action( 'clear_medias_with_invalid_wp_metas_cache' ), array( $this, 'clear_medias_with_invalid_wp_metas_cache_cb' ) );
 
@@ -283,20 +280,6 @@ class IMGT_Admin_Post {
 		imagify_tools_delete_site_transient( 'imgt_user' );
 
 		$this->redirect( 'imagify_user_cache_cleared', __( 'Imagify User cache cleared.', 'imagify-tools' ) );
-	}
-
-	/**
-	 * Admin post callback that allows to clear the cache used for medias without WP metas (Infos page).
-	 *
-	 * @since  1.0.2
-	 * @author Grégory Viguier
-	 */
-	public function clear_medias_without_wp_metas_cache_cb() {
-		$this->check_nonce_and_user( self::get_action( 'clear_medias_without_wp_metas_cache' ) );
-
-		imagify_tools_delete_site_transient( 'imgt_medias_no_wp_metas' );
-
-		$this->redirect( 'imagify_medias_without_wp_metas_cache_cleared', __( 'Cache for medias without WP metas cleared.', 'imagify-tools' ) );
 	}
 
 	/**

--- a/classes/class-imgt-admin-post.php
+++ b/classes/class-imgt-admin-post.php
@@ -15,7 +15,7 @@ class IMGT_Admin_Post {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.0';
+	const VERSION = '1.0.1';
 
 	/**
 	 * A prefix used in various places.
@@ -76,31 +76,37 @@ class IMGT_Admin_Post {
 		 * Logs.
 		 */
 		// Download Logs list.
-		add_action( 'admin_post_' . self::get_action( 'download_logs' ),            array( $this, 'download_logs_cb' ) );
+		add_action( 'admin_post_' . self::get_action( 'download_logs' ),                            array( $this, 'download_logs_cb' ) );
 
 		// Delete all Logs list.
-		add_action( 'admin_post_' . self::get_action( 'delete_logs' ),              array( $this, 'clear_logs_cb' ) );
+		add_action( 'admin_post_' . self::get_action( 'delete_logs' ),                              array( $this, 'clear_logs_cb' ) );
 
 		// Bulk delete Logs.
-		add_action( 'admin_post_' . self::get_action( 'bulk_delete_logs' ),         array( $this, 'bulk_delete_logs_cb' ) );
+		add_action( 'admin_post_' . self::get_action( 'bulk_delete_logs' ),                         array( $this, 'bulk_delete_logs_cb' ) );
 
 		// Delete a Log.
-		add_action( 'admin_post_' . self::get_action( 'delete_log' ),               array( $this, 'delete_log_cb' ) );
+		add_action( 'admin_post_' . self::get_action( 'delete_log' ),                               array( $this, 'delete_log_cb' ) );
 
 		// Blocking requests.
-		add_action( 'admin_post_' . self::get_action( 'switch_blocking_requests' ), array( $this, 'switch_blocking_requests_cb' ) );
+		add_action( 'admin_post_' . self::get_action( 'switch_blocking_requests' ),                 array( $this, 'switch_blocking_requests_cb' ) );
 
 		// Clear request cache.
-		add_action( 'admin_post_' . self::get_action( 'clear_request_cache' ),      array( $this, 'clear_request_cache_cb' ) );
+		add_action( 'admin_post_' . self::get_action( 'clear_request_cache' ),                      array( $this, 'clear_request_cache_cb' ) );
 
 		// Clear Imagify user cache.
-		add_action( 'admin_post_' . self::get_action( 'clear_imagify_user_cache' ), array( $this, 'clear_imagify_user_cache_cb' ) );
+		add_action( 'admin_post_' . self::get_action( 'clear_imagify_user_cache' ),                 array( $this, 'clear_imagify_user_cache_cb' ) );
+
+		// Clear missing metas cache.
+		add_action( 'admin_post_' . self::get_action( 'clear_medias_without_wp_metas_cache' ),      array( $this, 'clear_medias_without_wp_metas_cache_cb' ) );
+
+		// Clear invalid metas cache.
+		add_action( 'admin_post_' . self::get_action( 'clear_medias_with_invalid_wp_metas_cache' ), array( $this, 'clear_medias_with_invalid_wp_metas_cache_cb' ) );
 
 		// Fix NGG table engine.
-		add_action( 'admin_post_' . self::get_action( 'fix_ngg_table_engine' ),     array( $this, 'fix_ngg_table_engine_cb' ) );
+		add_action( 'admin_post_' . self::get_action( 'fix_ngg_table_engine' ),                     array( $this, 'fix_ngg_table_engine_cb' ) );
 
 		// Uninstall this plugin (when a MU Plugin).
-		add_action( 'admin_post_' . self::get_action( 'uninstall' ),                array( $this, 'uninstall_cb' ) );
+		add_action( 'admin_post_' . self::get_action( 'uninstall' ),                                array( $this, 'uninstall_cb' ) );
 	}
 
 
@@ -277,6 +283,34 @@ class IMGT_Admin_Post {
 		imagify_tools_delete_site_transient( 'imgt_user' );
 
 		$this->redirect( 'imagify_user_cache_cleared', __( 'Imagify User cache cleared.', 'imagify-tools' ) );
+	}
+
+	/**
+	 * Admin post callback that allows to clear the cache used for medias without WP metas (Infos page).
+	 *
+	 * @since  1.0.2
+	 * @author Grégory Viguier
+	 */
+	public function clear_medias_without_wp_metas_cache_cb() {
+		$this->check_nonce_and_user( self::get_action( 'clear_medias_without_wp_metas_cache' ) );
+
+		imagify_tools_delete_site_transient( 'imgt_medias_no_wp_metas' );
+
+		$this->redirect( 'imagify_medias_without_wp_metas_cache_cleared', __( 'Cache for medias without WP metas cleared.', 'imagify-tools' ) );
+	}
+
+	/**
+	 * Admin post callback that allows to clear the cache used for medias without WP metas (Infos page).
+	 *
+	 * @since  1.0.2
+	 * @author Grégory Viguier
+	 */
+	public function clear_medias_with_invalid_wp_metas_cache_cb() {
+		$this->check_nonce_and_user( self::get_action( 'clear_medias_with_invalid_wp_metas_cache' ) );
+
+		imagify_tools_delete_site_transient( 'imgt_medias_invalid_wp_metas' );
+
+		$this->redirect( 'imagify_medias_with_invalid_wp_metas_cache_cleared', __( 'Cache for medias with invalid WP metas cleared.', 'imagify-tools' ) );
 	}
 
 	/**

--- a/classes/class-imgt-attachments-metas.php
+++ b/classes/class-imgt-attachments-metas.php
@@ -15,7 +15,7 @@ class IMGT_Attachments_Metas {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.0';
+	const VERSION = '1.0.1';
 
 	/**
 	 * Meta box ID.
@@ -220,24 +220,31 @@ class IMGT_Attachments_Metas {
 				continue;
 			}
 
-			$nbr_metas = count( $meta_values );
+			$multiple_metas = count( $meta_values ) > 1;
 
 			echo '<tr>';
+			echo '<th>' . $meta_name . '</th>';
+			echo '<td>';
 
-			echo '<th' . ( $nbr_metas > 1 ? ' rowspan="' . $nbr_metas . '"' : '' ) . '>' . $meta_name . '</th>';
+			$separator = '';
 
 			foreach ( $meta_values as $meta_value ) {
-				echo '<td><pre>';
-
 				if ( is_numeric( $meta_value ) || is_null( $meta_value ) || is_bool( $meta_value ) ) {
+					ob_start();
 					call_user_func( 'var_dump', $meta_value );
+					$meta_value = trim( strip_tags( ob_get_clean() ) );
+					$meta_value = preg_replace( '@^.+\.php:\d+:@', '', $meta_value );
+					$meta_value = preg_replace( '@\(length=\d+\)$@', '<em><small>\0</small></em>', $meta_value );
 				} else {
-					echo esc_html( call_user_func( 'print_r', $meta_value, 1 ) );
+					$meta_value = esc_html( call_user_func( 'print_r', $meta_value, 1 ) );
 				}
 
-				echo '</pre></td>';
+				echo $separator;
+				echo '<pre>' . $meta_value . '</pre>';
+				$separator = $multiple_metas ? '<hr/>' : '';
 			}
 
+			echo '</td>';
 			echo '</tr>';
 		}
 

--- a/classes/class-imgt-log.php
+++ b/classes/class-imgt-log.php
@@ -16,7 +16,7 @@ class IMGT_Log {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.0';
+	const VERSION = '1.0.1';
 
 	/**
 	 * A DATETIME formated date.
@@ -341,7 +341,7 @@ class IMGT_Log {
 
 		$ajax_url = preg_quote( admin_url( 'admin-ajax.php' ), '@' );
 
-		if ( isset( $args['method'], $args['body']['action'] ) && 'POST' === strtoupper( $args['method'] ) && preg_match( '@^imagify_@', $args['body']['action'] ) && preg_match( '@^' . $ajax_url . '@', $url ) ) {
+		if ( isset( $args['method'], $args['body']['action'] ) && 'POST' === strtoupper( $args['method'] ) && 0 === strpos( 'imagify_', $args['body']['action'] ) && preg_match( '@^' . $ajax_url . '@', $url ) ) {
 			return compact( 'url', 'args', 'response' );
 		}
 


### PR DESCRIPTION
New row in the infos page that tells the number of image attachment without mandatory WP metas (aka `_wp_attached_file` and `_wp_attachment_metadata`) or with invalid ones.