### PR TITLE
Remove amazon storage urls

### DIFF
--- a/classes/class-imgt-admin-model-main.php
+++ b/classes/class-imgt-admin-model-main.php
@@ -465,8 +465,6 @@ class IMGT_Admin_Model_Main {
 		$imagify_urls = array(
 			'https://imagify.io',
 			'https://app.imagify.io/api/version/',
-			'https://s2-amz-par.imagify.io/wpm.png',
-			'http://storage.imagify.io/images/index.png',
 		);
 
 		foreach ( $imagify_urls as $imagify_url ) {

--- a/classes/class-imgt-admin-pages.php
+++ b/classes/class-imgt-admin-pages.php
@@ -129,7 +129,7 @@ class IMGT_Admin_Pages {
 		global $submenu;
 
 		$capability   = imagify_tools_get_capacity();
-		$current_page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
+		$current_page = filter_input( INPUT_GET, 'page' );
 
 		foreach ( self::$pages_data as $query_arg => $args ) {
 			if ( self::MAIN_PAGE_SLUG === $query_arg ) {


### PR DESCRIPTION
# Description

Fixes an issue reported in slack: https://wp-media.slack.com/archives/CU0F6EGQ1/p1735798532022589

Remove not needed amazon storage servers

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

Remove not needed amazon storage servers:
```
https://s2-amz-par.imagify.io/wpm.png
http://storage.imagify.io/images/index.png
```

## Technical description

### Documentation

We stopped our amazon account so we need to depend only on `app.imagify.io`

### New dependencies

No

### Risks

No

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No tests here.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
